### PR TITLE
fix(tsup): cleanup config options

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,6 @@
 		"eslint": "^8.5.0",
 		"eslint-config-prettier": "^8.3.0",
 		"eslint-plugin-prettier": "^4.0.0",
-		"globby": "^12.0.2",
 		"prettier": "^2.5.1",
 		"pretty-quick": "^3.1.3",
 		"tsup": "^5.11.9",

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -1,15 +1,9 @@
-import { globbySync } from 'globby';
 import { defineConfig } from 'tsup';
-
-const tsFiles = globbySync([
-	'src/**/*.ts', //
-	'!src/**/*.d.ts'
-]);
 
 export default defineConfig((options) => ({
 	clean: true,
 	dts: false,
-	entryPoints: tsFiles,
+	entry: ['src/**/*.ts', '!src/**/*.d.ts'],
 	format: ['esm'],
 	minify: false,
 	watch: options.watch,

--- a/yarn.lock
+++ b/yarn.lock
@@ -613,7 +613,6 @@ __metadata:
     eslint: ^8.5.0
     eslint-config-prettier: ^8.3.0
     eslint-plugin-prettier: ^4.0.0
-    globby: ^12.0.2
     marked: ^4.0.8
     node-html-to-image: ^3.2.0
     prettier: ^2.5.1
@@ -656,13 +655,6 @@ __metadata:
   version: 2.1.0
   resolution: "array-union@npm:2.1.0"
   checksum: 5bee12395cba82da674931df6d0fea23c4aa4660cb3b338ced9f828782a65caa232573e6bf3968f23e0c5eb301764a382cef2f128b170a9dc59de0e36c39f98d
-  languageName: node
-  linkType: hard
-
-"array-union@npm:^3.0.1":
-  version: 3.0.1
-  resolution: "array-union@npm:3.0.1"
-  checksum: 47b29f88258e8f37ffb93ddaa327d4308edd950b52943c172b73558afdd3fa74cfd68816ba5aa4b894242cf281fa3c6d0362ae057e4a18bddbaedbe46ebe7112
   languageName: node
   linkType: hard
 
@@ -1542,7 +1534,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fast-glob@npm:^3.1.1, fast-glob@npm:^3.2.7":
+"fast-glob@npm:^3.1.1":
   version: 3.2.7
   resolution: "fast-glob@npm:3.2.7"
   dependencies:
@@ -1802,20 +1794,6 @@ __metadata:
     merge2: ^1.3.0
     slash: ^3.0.0
   checksum: d3e02d5e459e02ffa578b45f040381c33e3c0538ed99b958f0809230c423337999867d7b0dbf752ce93c46157d3bbf154d3fff988a93ccaeb627df8e1841775b
-  languageName: node
-  linkType: hard
-
-"globby@npm:^12.0.2":
-  version: 12.0.2
-  resolution: "globby@npm:12.0.2"
-  dependencies:
-    array-union: ^3.0.1
-    dir-glob: ^3.0.1
-    fast-glob: ^3.2.7
-    ignore: ^5.1.8
-    merge2: ^1.4.1
-    slash: ^4.0.0
-  checksum: f474ced866755f48ce7e8a7e11b0a1d90fa1f1c25cf86c245fbf05a862accfba695102a843b6386dbe41fa73c2f9a7e625bf566fa7648d2e1304f58748975e3f
   languageName: node
   linkType: hard
 
@@ -2217,7 +2195,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"merge2@npm:^1.3.0, merge2@npm:^1.4.1":
+"merge2@npm:^1.3.0":
   version: 1.4.1
   resolution: "merge2@npm:1.4.1"
   checksum: 7268db63ed5169466540b6fb947aec313200bcf6d40c5ab722c22e242f651994619bcd85601602972d3c85bd2cc45a358a4c61937e9f11a061919a1da569b0c2
@@ -2969,13 +2947,6 @@ __metadata:
   version: 3.0.0
   resolution: "slash@npm:3.0.0"
   checksum: 94a93fff615f25a999ad4b83c9d5e257a7280c90a32a7cb8b4a87996e4babf322e469c42b7f649fd5796edd8687652f3fb452a86dc97a816f01113183393f11c
-  languageName: node
-  linkType: hard
-
-"slash@npm:^4.0.0":
-  version: 4.0.0
-  resolution: "slash@npm:4.0.0"
-  checksum: da8e4af73712253acd21b7853b7e0dbba776b786e82b010a5bfc8b5051a1db38ed8aba8e1e8f400dd2c9f373be91eb1c42b66e91abb407ff42b10feece5e1d2d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
- tsup uses globby [internally](https://github.com/egoist/tsup/blob/40951ecb4e3d9317a9da54d3ef2b55b23073a4a4/src/index.ts#L89-L97), so there's no need to use it in the config (and add another line to your precious package.json)
- `entryPoints` is [deprecated](https://github.com/egoist/tsup/blob/40951ecb4e3d9317a9da54d3ef2b55b23073a4a4/src/options.ts#L26-L30), use `entry` instead