### PR TITLE
fix(tsup): use CLI overrides directly

### DIFF
--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -1,12 +1,11 @@
 import { defineConfig } from 'tsup';
 
-export default defineConfig((options) => ({
+export default defineConfig({
 	clean: true,
 	dts: false,
 	entry: ['src/**/*.ts', '!src/**/*.d.ts'],
 	format: ['esm'],
 	minify: false,
-	watch: options.watch,
 	skipNodeModulesBundle: true,
 	sourcemap: true,
 	target: 'esnext',
@@ -15,4 +14,4 @@ export default defineConfig((options) => ({
 	shims: false,
 	keepNames: true,
 	splitting: false
-}));
+});


### PR DESCRIPTION
sorry for the PR spam lmao I forgot to add this in the last cleanup, but `watch` is an option that can be overridden directly via the CLI, so putting it in the config as a conditional is redundant